### PR TITLE
Remove unnecessary mut from browser test

### DIFF
--- a/tests/browser.rs
+++ b/tests/browser.rs
@@ -7,7 +7,7 @@ use winit::keyboard::ModifiersState;
 #[test]
 fn browser_history_navigation() {
     let history = Rc::new(History::new("first".into()));
-    let mut browser = Browser {
+    let browser = Browser {
         #[cfg(feature = "browser")]
         window: None,
         #[cfg(feature = "browser")]


### PR DESCRIPTION
## Summary
- cleanup: `mut` is not needed in `browser` test

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_6862bde188808324be135eb9f38df3e8